### PR TITLE
Remove the need to use package protected stuff + fix object fragment tag

### DIFF
--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/BackstackActivity.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/BackstackActivity.kt
@@ -71,7 +71,10 @@ abstract class BackstackActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         backstack.executePendingStateChange()
-        backstack.finalizeScopes()
+
+        if (isFinishing) {
+            backstack.finalizeScopes()
+        }
     }
 
     private class BackstackHolderViewModel(val backstack: Backstack) : ViewModel()

--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/BackstackActivity.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/BackstackActivity.kt
@@ -47,6 +47,12 @@ abstract class BackstackActivity : AppCompatActivity() {
         return backstack
     }
 
+    override fun onBackPressed() {
+        if (!backstack.goBack()) {
+            super.onBackPressed()
+        }
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putParcelable("BACKSTACK_STATE", backstack.toBundle())

--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/MainActivity.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/MainActivity.kt
@@ -4,10 +4,8 @@ import android.os.Bundle
 import com.matejdro.simple_stack_dagger_demo.base.FragmentStateChanger
 import com.matejdro.simple_stack_dagger_demo.di.BackstackModule
 import com.matejdro.simple_stack_dagger_demo.di.MainActivitySubcomponent
-import com.zhuinden.simplestack.Backstack
-import com.zhuinden.simplestack.navigator.BackstackActivity
-import com.zhuinden.simplestack.navigator.Navigator
 import com.matejdro.simple_stack_dagger_demo.features.words.WordListKey
+import com.matejdro.simple_stack_dagger_demo.utils.NoOpStateChanger
 
 class MainActivity : BackstackActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,42 +17,18 @@ class MainActivity : BackstackActivity() {
 
         supportFragmentManager.fragmentFactory = component.provideFragmentFactory()
 
-        val backstackInstaller = Navigator.configure()
-            .setScopedServices(component.provideScopedServices())
-
         val backstack =
-            initBackstack(backstackInstaller, savedInstanceState, listOf(WordListKey))
+            initBackstack(savedInstanceState, listOf(WordListKey)) {
+                setScopedServices(component.provideScopedServices())
+            }
+
         backstackModule.backstack = backstack
 
-        if (savedInstanceState != null) {
-            backstack.initStateChanger()
-        }
-
+        backstack.setStateChanger(NoOpStateChanger) // force creation of scoped services
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        if (savedInstanceState == null) {
-            backstack.initStateChanger()
-        }
-    }
-
-    /**
-     * HACK:
-     *
-     * setStateChanger() line appears to both initialize scoped services and
-     * trigger first state change.
-     *
-     * When activity is created for the first time, we want to set state changer AFTER
-     * super.onCreate() when fragment manager is ready, so simple-stack can perform first state change.
-     *
-     * However, when activity is restored from saved state, we need scoped services to be initialized
-     * when fragments are being recreated (so we can perform constructor injection).
-     * That is why state changer needs to set BEFORE super.onCreate(). First state change does
-     * not appear to be the problem, since there no state changes need to be performed - everything
-     * is restored from saved state.
-     */
-    private fun Backstack.initStateChanger() {
-        setStateChanger(
+        backstack.setStateChanger(
             FragmentStateChanger(
                 supportFragmentManager.fragmentFactory,
                 supportFragmentManager,

--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/features/words/NewWordKey.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/features/words/NewWordKey.kt
@@ -11,4 +11,7 @@ object NewWordKey : FragmentKey(), ScopeKey.Child {
 
     override fun getParentScopes(): List<String> =
         listOf(WordController::class.java.name)
+
+    override val fragmentTag: String
+        get() = javaClass.name // object toString() includes hashCode()
 }

--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/features/words/WordListKey.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/features/words/WordListKey.kt
@@ -15,4 +15,6 @@ object WordListKey : FragmentKey(), ScopeKey.Child {
     override fun getParentScopes(): List<String> =
         listOf(WordController::class.java.name)
 
+    override val fragmentTag: String
+        get() = javaClass.name // object toString() includes hashCode()
 }

--- a/app/src/main/java/com/matejdro/simple_stack_dagger_demo/utils/NoOpStateChanger.kt
+++ b/app/src/main/java/com/matejdro/simple_stack_dagger_demo/utils/NoOpStateChanger.kt
@@ -1,0 +1,10 @@
+package com.matejdro.simple_stack_dagger_demo.utils
+
+import com.zhuinden.simplestack.StateChange
+import com.zhuinden.simplestack.StateChanger
+
+object NoOpStateChanger : StateChanger {
+    override fun handleStateChange(stateChange: StateChange, completionCallback: StateChanger.Callback) {
+        completionCallback.stateChangeComplete()
+    }
+}


### PR DESCRIPTION
Object `toString()` by default contains its hashCode, but hashCode varies across processes, therefore the fragment tags in the sample were not stable, which broke back navigation after process death.

Also, if you are retaining the Backstack yourself across config changes + manage its lifecycle methods, then you don't need to tinker with Navigator.

----

I'm hopeful that we can somehow move the instantiation of `Backstack` into the subcomponent.

Maybe we can `@BindsInstance` an `Optional<Bundle>` of `savedInstanceState`, AND move the `ViewModelProviders.of()` call into a module?

Either way, that is outside the scope of this PR.